### PR TITLE
Chore: remove AWS credentials mount

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -12,6 +12,3 @@ services:
       - type: bind
         source: ..
         target: /utkusarioglu-com/aws-automation-setup
-      - type: bind
-        source: ../.secrets/aws
-        target: /home/terraform/.aws


### PR DESCRIPTION
- Remove AWS credentials mount in favor of using Terraform api to
  provide these secrets.
